### PR TITLE
Add shift schedule sync

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -14,7 +14,11 @@ from database.models import async_main
 from services.reports import send_monthly_reports
 from services.survey_reset import reset_surveys_and_notify_users
 from services.survey_scheduler import send_surveys
-from utils import update_pairs_from_sheet, export_answers_to_google_sheet
+from utils import (
+    update_pairs_from_sheet,
+    export_answers_to_google_sheet,
+    update_shifts_from_sheet,
+)
 from logger import setup_logger
 
 
@@ -36,6 +40,7 @@ async def main():
 
     scheduler = AsyncIOScheduler()
     scheduler.add_job(update_pairs_from_sheet, 'cron', hour=19, minute=50)
+    scheduler.add_job(update_shifts_from_sheet, 'cron', hour=6, minute=0)
     scheduler.add_job(send_surveys, 'cron', hour=20, minute=0, args=[bot, dp])
     scheduler.add_job(export_answers_to_google_sheet, 'cron', day_of_week='sun', hour=23, minute=0)
     scheduler.add_job(send_monthly_reports, 'cron', day=1, hour=16, minute=38, args=[bot])

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -89,6 +89,7 @@ class Shift(Base):
     doctor_name = Column(Text)
     date = Column(String(31))
     type = Column(String(10))
+    assistant_name = Column(Text, nullable=True)
 
 
 async def async_main():

--- a/app/handlers/admin_handlers.py
+++ b/app/handlers/admin_handlers.py
@@ -2,8 +2,14 @@ from aiogram import Router
 from aiogram.filters import Command
 from aiogram.types import Message
 
-from utils import update_data_from_sheets, update_surveys_from_sheet, update_pairs_from_sheet, \
-    update_workers_from_sheet, export_answers_to_google_sheet
+from utils import (
+    update_data_from_sheets,
+    update_surveys_from_sheet,
+    update_pairs_from_sheet,
+    update_workers_from_sheet,
+    update_shifts_from_sheet,
+    export_answers_to_google_sheet,
+)
 
 router = Router()
 
@@ -34,6 +40,13 @@ async def update_surveys(message: Message):
     msg = await message.answer('⏳ Загрузка...')
     await update_surveys_from_sheet()
     await msg.edit_text("✅ Данные об опросах успешно загружены в базу данных.")
+
+
+@router.message(Command('upd_shifts'))
+async def update_shifts(message: Message):
+    msg = await message.answer('⏳ Загрузка...')
+    await update_shifts_from_sheet()
+    await msg.edit_text("✅ Данные о сменах успешно загружены в базу данных.")
 
 
 @router.message(Command('export'))


### PR DESCRIPTION
## Summary
- remove `Doctor` and `DoctorSchedule` models
- store daily doctor plan directly in `Shift` with optional `assistant_name`
- sync shifts from the fifth worksheet
- update `/shift` workflow to reserve existing rows
- rename admin command to `/upd_shifts`

## Testing
- `python -m py_compile app/bot.py app/database/models.py app/database/requests.py app/utils.py app/handlers/admin_handlers.py app/handlers/shift_handlers.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce49c81948322829facd9297dc030