### PR TITLE
Add shift cancel and manual check-in

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -2,7 +2,7 @@ import os
 
 from dotenv import load_dotenv
 
-from sqlalchemy import BigInteger, String, Text, Column
+from sqlalchemy import BigInteger, String, Text, Column, Boolean
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy.ext.asyncio import AsyncAttrs, async_sessionmaker, create_async_engine
 
@@ -90,6 +90,7 @@ class Shift(Base):
     date = Column(String(31))
     type = Column(String(10))
     assistant_name = Column(Text, nullable=True)
+    manual = Column(Boolean, default=False)
 
 
 async def async_main():

--- a/app/handlers/shift_handlers.py
+++ b/app/handlers/shift_handlers.py
@@ -5,7 +5,11 @@ from aiogram.filters import Command
 from aiogram.types import Message, CallbackQuery
 
 import database.requests as rq
-from keyboards import build_doctors_keyboard
+from keyboards import (
+    build_doctors_keyboard,
+    build_all_doctors_keyboard,
+    build_cancel_shift_keyboard,
+)
 from logger import setup_logger
 
 router = Router()
@@ -26,6 +30,19 @@ async def show_doctors(message: Message):
         return
 
     date_str = now.strftime("%d.%m.%Y")
+    worker = await rq.get_worker_by_chat_id(message.from_user.id)
+    if not worker:
+        await message.answer("Вы не зарегистрированы")
+        return
+
+    current_shift = await rq.get_assistant_shift(worker.id, date_str, shift_type)
+    if current_shift:
+        await message.answer(
+            f"Вы уже записаны к {current_shift.doctor_name}",
+            reply_markup=build_cancel_shift_keyboard(shift_type),
+        )
+        return
+
     doctor_names = await rq.get_free_doctors(date_str, shift_type)
     if not doctor_names:
         await message.answer("Список врачей пуст")
@@ -71,5 +88,86 @@ async def mark_shift(callback: CallbackQuery):
     else:
         await callback.message.edit_text(
             "❌ Вы уже записаны у другого врача или выбранный слот занят"
+        )
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("cancel_shift:"))
+async def cancel_shift(callback: CallbackQuery):
+    shift_type = callback.data.split(":", 1)[1]
+    now = datetime.now()
+    date_str = now.strftime("%d.%m.%Y")
+    worker = await rq.get_worker_by_chat_id(callback.from_user.id)
+    if worker:
+        await rq.remove_shift(worker.id, date_str, shift_type)
+        await callback.message.edit_text("✅ Запись отменена")
+    await callback.answer()
+
+
+@router.message(Command("shift_any"))
+async def manual_shift(message: Message):
+    now = datetime.now()
+    hour = now.hour
+    if 8 <= hour < 14:
+        shift_type = "morning"
+    elif 14 <= hour < 20:
+        shift_type = "evening"
+    else:
+        await message.answer("Отмечаться можно с 8 до 20")
+        return
+
+    date_str = now.strftime("%d.%m.%Y")
+    worker = await rq.get_worker_by_chat_id(message.from_user.id)
+    if not worker:
+        await message.answer("Вы не зарегистрированы")
+        return
+
+    current_shift = await rq.get_assistant_shift(worker.id, date_str, shift_type)
+    if current_shift:
+        await message.answer(
+            f"Вы уже записаны к {current_shift.doctor_name}",
+            reply_markup=build_cancel_shift_keyboard(shift_type),
+        )
+        return
+
+    await message.answer(
+        "Выберите врача:",
+        reply_markup=await build_all_doctors_keyboard(),
+    )
+
+
+@router.callback_query(F.data.startswith("manual_select_doctor:"))
+async def mark_manual(callback: CallbackQuery):
+    doctor_name = callback.data.split(":", 1)[1]
+    now = datetime.now()
+    hour = now.hour
+    if 8 <= hour < 14:
+        shift_type = "morning"
+    elif 14 <= hour < 20:
+        shift_type = "evening"
+    else:
+        await callback.answer("Отмечать смену можно с 8 до 20", show_alert=True)
+        return
+
+    worker = await rq.get_worker_by_chat_id(callback.from_user.id)
+    if not worker:
+        await callback.answer("Вы не зарегистрированы", show_alert=True)
+        return
+
+    date_str = now.strftime("%d.%m.%Y")
+    success = await rq.add_manual_shift(
+        worker.id,
+        worker.full_name,
+        doctor_name,
+        shift_type,
+        date_str,
+    )
+    if success:
+        await callback.message.edit_text(
+            f"✅ Смена {shift_type} для {doctor_name} отмечена (вручную)"
+        )
+    else:
+        await callback.message.edit_text(
+            "❌ Вы уже записаны на эту смену"
         )
     await callback.answer()

--- a/app/keyboards.py
+++ b/app/keyboards.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
-from database.requests import get_unregistered_workers
+from database.requests import get_unregistered_workers, get_all_workers
 
 
 async def build_worker_keyboard() -> InlineKeyboardMarkup:
@@ -63,5 +63,27 @@ async def build_doctors_keyboard(doctors: list[str]) -> InlineKeyboardMarkup:
             text=doc,
             callback_data=f"select_doctor:{doc}"
         )
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+async def build_all_doctors_keyboard() -> InlineKeyboardMarkup:
+    workers = await get_all_workers()
+    builder = InlineKeyboardBuilder()
+    for worker in workers:
+        builder.button(
+            text=worker.full_name,
+            callback_data=f"manual_select_doctor:{worker.full_name}"
+        )
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def build_cancel_shift_keyboard(shift_type: str) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(
+        text="Отменить запись",
+        callback_data=f"cancel_shift:{shift_type}"
+    )
     builder.adjust(1)
     return builder.as_markup()


### PR DESCRIPTION
## Summary
- mark manual check-ins with a flag
- allow cancelling a shift
- support manual doctor selection via `/shift_any`
- show current appointment when `/shift` is pressed again

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6889b3de2fe88322b9b873cf46856509