### PR TITLE
Fix shift selection callback by using shift IDs

### DIFF
--- a/app/keyboards.py
+++ b/app/keyboards.py
@@ -57,12 +57,12 @@ async def build_int_keyboard(question_index) -> InlineKeyboardMarkup:
     return builder.as_markup()
 
 
-async def build_doctors_keyboard(doctors: list[str]) -> InlineKeyboardMarkup:
+async def build_shift_keyboard(shifts: list[tuple[int, str]]) -> InlineKeyboardMarkup:
     builder = InlineKeyboardBuilder()
-    for doc in doctors:
+    for shift_id, name in shifts:
         builder.button(
-            text=doc,
-            callback_data=f"select_doctor:{doc}"
+            text=name,
+            callback_data=f"select_shift:{shift_id}"
         )
     builder.adjust(1)
     return builder.as_markup()


### PR DESCRIPTION
## Summary
- Use shift IDs instead of doctor names in callback data to avoid Telegram length limits
- Support shift options beyond doctor names and validate shift selection
- Add database helpers for shift lookup and assignment by ID

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad9c1704608322bb01ed3e232cf322